### PR TITLE
Should have timeout on http client connections

### DIFF
--- a/csiplugin/connectors/rest_v2.go
+++ b/csiplugin/connectors/rest_v2.go
@@ -139,7 +139,15 @@ func NewSpectrumRestV2(scaleConfig settings.Clusters) (SpectrumScaleConnector, e
 		glog.V(4).Infof("Created Spectrum Scale connector without SSL mode for %v", guiHost)
 	}
 
-	return &spectrumRestV2{httpClient: &http.Client{Transport: tr}, endpoint: endpoint, user: guiUser, password: guiPwd}, nil
+	return &spectrumRestV2{
+		httpClient: &http.Client{
+			Transport: tr,
+			Timeout:   time.Second * 10,
+		},
+		endpoint: endpoint,
+		user:     guiUser,
+		password: guiPwd,
+	}, nil
 }
 
 func (s *spectrumRestV2) GetClusterId() (string, error) {


### PR DESCRIPTION
We create http.Client without specifying Timeout.  This means the struct is created with Timeout zero-value (0), which corresponds to NO timeout.  We could leak goroutines when trying to make a connection, while CO will properly timeout and try again (potentially creating more leaked routines).

Here is the relevant code (line 142), since it is hard to read diff without gofmt changes.
```go
	return &spectrumRestV2{
		httpClient: &http.Client{
			Transport: tr,
			Timeout:   time.Second * 10,
		},
		endpoint: endpoint,
		user:     guiUser,
		password: guiPwd,
	}, nil
```