### PR TITLE
Node mapping

### DIFF
--- a/csiplugin/controllerserver.go
+++ b/csiplugin/controllerserver.go
@@ -793,7 +793,17 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	}
 
 	// Node mapping check
-	scalenodeID := utils.GetEnv(nodeID, nodeID)
+	scalenodeID := utils.GetEnv(nodeID, "NOT_FOUND")
+	// Additional node mapping check in case of k8s node id is IP address.
+	if scalenodeID == "NOT_FOUND" {
+		prefix := utils.GetEnv("SCALE_NODE_MAPPING_PREFIX", "K8SIP_")
+		scalenodeID = utils.GetEnv(prefix+nodeID, "NOT_FOUND")
+		if scalenodeID == "NOT_FOUND" {
+			glog.V(4).Infof("ControllerPublishVolume : scale node mapping not found for %s", prefix+nodeID)
+			scalenodeID = nodeID
+		}
+	}
+
 	glog.V(4).Infof("ControllerUnpublishVolume : scalenodeID:%s --known as-- k8snodeName: %s", scalenodeID, nodeID)
 	ispFsMounted := utils.StringInSlice(scalenodeID, pfsMount.NodesMounted)
 

--- a/csiplugin/controllerserver.go
+++ b/csiplugin/controllerserver.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	no  = "no"
-	yes = "yes"
+	no       = "no"
+	yes      = "yes"
+	notFound = "NOT_FOUND"
 )
 
 type ScaleControllerServer struct {
@@ -793,13 +794,12 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	}
 
 	// Node mapping check
-	const notFoundString = "NOT_FOUND"
-	scalenodeID := utils.GetEnv(nodeID, notFoundString)
-	// Additional node mapping check in case of k8s node id is IP address.
-	if scalenodeID == notFoundString {
-		prefix := utils.GetEnv("SCALE_NODE_MAPPING_PREFIX", "K8SIP_")
-		scalenodeID = utils.GetEnv(prefix+nodeID, notFoundString)
-		if scalenodeID == notFoundString {
+	scalenodeID := utils.GetEnv(nodeID, notFound)
+	// Additional node mapping check in case of k8s node id start with number.
+	if scalenodeID == notFound {
+		prefix := utils.GetEnv("SCALE_NODE_MAPPING_PREFIX", "K8sNodePrefix_")
+		scalenodeID = utils.GetEnv(prefix+nodeID, notFound)
+		if scalenodeID == notFound {
 			glog.V(4).Infof("ControllerPublishVolume : scale node mapping not found for %s using %s", prefix+nodeID, nodeID)
 			scalenodeID = nodeID
 		}

--- a/csiplugin/controllerserver.go
+++ b/csiplugin/controllerserver.go
@@ -793,12 +793,13 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	}
 
 	// Node mapping check
-	scalenodeID := utils.GetEnv(nodeID, "NOT_FOUND")
+	cont notFoundString = "NOT_FOUND"
+	scalenodeID := utils.GetEnv(nodeID, notFoundString)
 	// Additional node mapping check in case of k8s node id is IP address.
-	if scalenodeID == "NOT_FOUND" {
+	if scalenodeID == notFoundString {
 		prefix := utils.GetEnv("SCALE_NODE_MAPPING_PREFIX", "K8SIP_")
-		scalenodeID = utils.GetEnv(prefix+nodeID, "NOT_FOUND")
-		if scalenodeID == "NOT_FOUND" {
+		scalenodeID = utils.GetEnv(prefix+nodeID, notFoundString)
+		if scalenodeID == notFoundString {
 			glog.V(4).Infof("ControllerPublishVolume : scale node mapping not found for %s using %s", prefix+nodeID, nodeID)
 			scalenodeID = nodeID
 		}

--- a/csiplugin/controllerserver.go
+++ b/csiplugin/controllerserver.go
@@ -799,7 +799,7 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 		prefix := utils.GetEnv("SCALE_NODE_MAPPING_PREFIX", "K8SIP_")
 		scalenodeID = utils.GetEnv(prefix+nodeID, "NOT_FOUND")
 		if scalenodeID == "NOT_FOUND" {
-			glog.V(4).Infof("ControllerPublishVolume : scale node mapping not found for %s", prefix+nodeID)
+			glog.V(4).Infof("ControllerPublishVolume : scale node mapping not found for %s using %s", prefix+nodeID, nodeID)
 			scalenodeID = nodeID
 		}
 	}

--- a/csiplugin/controllerserver.go
+++ b/csiplugin/controllerserver.go
@@ -793,7 +793,7 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	}
 
 	// Node mapping check
-	cont notFoundString = "NOT_FOUND"
+	const notFoundString = "NOT_FOUND"
 	scalenodeID := utils.GetEnv(nodeID, notFoundString)
 	// Additional node mapping check in case of k8s node id is IP address.
 	if scalenodeID == notFoundString {


### PR DESCRIPTION
Fixing node mapping when k8s node id is IP address. 
In case of k8s nodeId is IP address user will have to create mapping with prefix "K8SIP_"
Example :  K8SIP_192.168.122.2
